### PR TITLE
constrast -> contrast

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,14 +17,14 @@ between foreground text colors and their background colors. The contrast ratio
 of two colors is a measurement of how much the brightness of two colors differ.
 For example, white on dark grey might have a contrast ratio of 9:1, while white
 on medium grey might only have a contrast ratio of 4:1. In general, larger
-constrast ratios are better and will ensure the widest range of users can easily
+contrast ratios are better and will ensure the widest range of users can easily
 read the text in your app.
 
 The [W3C](https://www.w3.org)'s
 [Web Content Accessibility Guidelines](https://www.w3.org/TR/WCAG/#visual-audio-contrast)
 contains two recommendations for text contrast ratios:
 
-1. Minimum constrast: text should have a contrast ratio of at least 4.5:1,
+1. Minimum contrast: text should have a contrast ratio of at least 4.5:1,
    except for "large" text, which can have a contrast ratio of 3:1.
 2. Enhanced contrast: text should have a contrast ratio of at least 7:1, except
    for large text, which can have a contrast ratio of 4.5:1.
@@ -34,7 +34,7 @@ least 14pt in a bold font face. For more information (including some important
 exceptions), see the
 [Guidelines](https://www.w3.org/TR/WCAG/#visual-audio-contrast).
 
-## Computing constrast ratios
+## Computing contrast ratios
 
 Computing acceptable contrast ratios involves the foreground color, the
 background color, the text size, and the transparency of the foreground color,
@@ -103,4 +103,3 @@ and black, see MDFTextAccessibility's
 ## License
 
 MDFTextAccessiblity is licensed under the [Apache License Version 2.0](LICENSE).
-

--- a/examples/apps/MDFTextAccessibilitySample/MDFTextAccessibilitySample/ColorsCollectionViewController.swift
+++ b/examples/apps/MDFTextAccessibilitySample/MDFTextAccessibilitySample/ColorsCollectionViewController.swift
@@ -57,7 +57,7 @@ private func setLabelAccessibleTextColor(label: UILabel,
 }
 
 /** A title containing a contrast ratio for a color ship. */
-private func constrastRatioTitle(prefix: String,
+private func contrastRatioTitle(prefix: String,
                                  textColor: UIColor,
                                  backgroundColor: UIColor) -> String {
   let ratio = MDFTextAccessibility.contrastRatioForTextColor(textColor,
@@ -148,10 +148,10 @@ class ColorsCollectionViewController: UICollectionViewController {
 
     cell.backgroundColorLabel.text = backgroundColorTitle("Background ",
                                                           backgroundColor:cell.backgroundColor!)
-    cell.largeTextLabel.text = constrastRatioTitle("Large text",
+    cell.largeTextLabel.text = contrastRatioTitle("Large text",
                                                    textColor:cell.largeTextLabel.textColor,
                                                    backgroundColor:cell.backgroundColor!)
-    cell.normalTextLabel.text = constrastRatioTitle("Normal text",
+    cell.normalTextLabel.text = contrastRatioTitle("Normal text",
                                                     textColor:cell.normalTextLabel.textColor,
                                                     backgroundColor:cell.backgroundColor!)
   }

--- a/src/MDFTextAccessibility.h
+++ b/src/MDFTextAccessibility.h
@@ -33,7 +33,7 @@ typedef NS_OPTIONS(NSUInteger, MDFTextAccessibilityOptions) {
   /** Prefer lighter colors to darker colors. */
   MDFTextAccessibilityOptionsPreferLighter = 1 << 3,
 
-  /** Use enhanced constrast ratios (level AAA) instead of minimum ratios (level AA). */
+  /** Use enhanced contrast ratios (level AAA) instead of minimum ratios (level AA). */
   MDFTextAccessibilityOptionsEnhancedContrast = 1 << 4,
 };
 


### PR DESCRIPTION
Very minor spelling error, but thought it worthwhile to get this correct.