### PR TITLE
Project Code Coverage

### DIFF
--- a/MDFTextAccessibility.xcodeproj/xcshareddata/xcschemes/MDFTextAccessibility.xcscheme
+++ b/MDFTextAccessibility.xcodeproj/xcshareddata/xcschemes/MDFTextAccessibility.xcscheme
@@ -26,7 +26,8 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      shouldUseLaunchSchemeArgsEnv = "YES">
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      codeCoverageEnabled = "YES">
       <Testables>
          <TestableReference
             skipped = "NO">


### PR DESCRIPTION
Small change to the schema to enable code coverage for the library.

Could take this one step further and enable slather for the project and signpost the level of code coverage for the library in the README file ala https://github.com/dasmer/DAZABTest?